### PR TITLE
Add netlify redirect rule

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200


### PR DESCRIPTION
These are to make sure all requests go through the index.html at Netlify so routing works as expected (including 404s).